### PR TITLE
Switch to BCrypt as standard

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,7 +33,7 @@ jobs:
           dotnet tool update dotnet-coverage --tool-path /tmp/coverage
       - name: SonarCloud Start
         run:
-          /tmp/sonar/dotnet-sonarscanner begin /k:"tspence_api-key-generator" /o:"tspence" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+          /tmp/sonar/dotnet-sonarscanner begin /k:"tspence_api-key-generator" /o:"tspence" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.coverage.exclusions=ApiKeyGenerator.Benchmarks/**
       - name: Build
         run: dotnet build
       - name: Test

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -3,8 +3,6 @@ name: NuGet Publish
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/ApiKeyGenerator.Benchmarks/AlgorithmBenchmarks.cs
+++ b/ApiKeyGenerator.Benchmarks/AlgorithmBenchmarks.cs
@@ -1,0 +1,59 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace ApiKeyGenerator.Benchmarks;
+
+public class AlgorithmBenchmarks
+{
+    private static TestRepository MakeTestRepository(HashAlgorithmType hash)
+    {
+        return new TestRepository()
+        {
+            Algorithm = new ApiKeyAlgorithm()
+            {
+                Hash = hash,
+                SaltLength = 64,
+                ClientSecretLength = 64,
+                Prefix = "key",
+                Suffix = "yek",
+            }
+        };
+    }
+
+    private readonly int iterations = 100000;
+    
+    [Params(HashAlgorithmType.SHA256, HashAlgorithmType.SHA512, HashAlgorithmType.BCrypt, HashAlgorithmType.PBKDF2100K)]
+    public HashAlgorithmType HashType { get; set; }
+
+    [Benchmark]
+    public async Task Generate()
+    {
+        var repository = MakeTestRepository(HashType);
+        var validator = new ApiKeyValidator(repository);
+        for (int i = 0; i < iterations; i++)
+        {
+            var persistedKey = new PersistedKey() { KeyName = $"Test Key {i}" };
+            var keyString = await validator.GenerateApiKey(persistedKey);
+            if (string.IsNullOrWhiteSpace(keyString))
+            {
+                throw new Exception("Failed to generate key");
+            }
+        }
+    }
+
+    [Benchmark]
+    public async Task Validate()
+    {
+        var sha256Repo = MakeTestRepository(HashType);
+        var validator = new ApiKeyValidator(sha256Repo);
+        var persistedKey = new PersistedKey() { KeyName = $"Test Key" };
+        var keyString = await validator.GenerateApiKey(persistedKey);
+        for (int i = 0; i < iterations; i++)
+        {
+            var result = await validator.TryValidate(keyString);
+            if (!result.Success)
+            {
+                throw new Exception("Failed to validate key");
+            }
+        }
+    }
+}

--- a/ApiKeyGenerator.Benchmarks/AlgorithmBenchmarks.cs
+++ b/ApiKeyGenerator.Benchmarks/AlgorithmBenchmarks.cs
@@ -19,8 +19,8 @@ public class AlgorithmBenchmarks
         };
     }
 
-    private readonly int iterations = 1000;
-    
+    private const int Iterations = 100;
+
     [Params(HashAlgorithmType.SHA256, HashAlgorithmType.SHA512, HashAlgorithmType.BCrypt, HashAlgorithmType.PBKDF2100K)]
     public HashAlgorithmType HashType { get; set; }
 
@@ -29,7 +29,7 @@ public class AlgorithmBenchmarks
     {
         var repository = MakeTestRepository(HashType);
         var validator = new ApiKeyValidator(repository);
-        for (int i = 0; i < iterations; i++)
+        for (int i = 0; i < Iterations; i++)
         {
             var persistedKey = new PersistedKey() { KeyName = $"Test Key {i}" };
             var keyString = await validator.GenerateApiKey(persistedKey);
@@ -48,7 +48,7 @@ public class AlgorithmBenchmarks
         var validator = new ApiKeyValidator(sha256Repo);
         var persistedKey = new PersistedKey() { KeyName = $"Test Key" };
         var keyString = await validator.GenerateApiKey(persistedKey);
-        for (int i = 0; i < iterations; i++)
+        for (int i = 0; i < Iterations; i++)
         {
             var result = await validator.TryValidate(keyString);
             if (!result.Success)

--- a/ApiKeyGenerator.Benchmarks/AlgorithmBenchmarks.cs
+++ b/ApiKeyGenerator.Benchmarks/AlgorithmBenchmarks.cs
@@ -19,7 +19,7 @@ public class AlgorithmBenchmarks
         };
     }
 
-    private readonly int iterations = 100000;
+    private readonly int iterations = 1000;
     
     [Params(HashAlgorithmType.SHA256, HashAlgorithmType.SHA512, HashAlgorithmType.BCrypt, HashAlgorithmType.PBKDF2100K)]
     public HashAlgorithmType HashType { get; set; }
@@ -35,7 +35,8 @@ public class AlgorithmBenchmarks
             var keyString = await validator.GenerateApiKey(persistedKey);
             if (string.IsNullOrWhiteSpace(keyString))
             {
-                throw new Exception("Failed to generate key");
+                Console.WriteLine("Failed to generate key");
+                return;
             }
         }
     }
@@ -52,7 +53,8 @@ public class AlgorithmBenchmarks
             var result = await validator.TryValidate(keyString);
             if (!result.Success)
             {
-                throw new Exception("Failed to validate key");
+                Console.WriteLine("Failed to validate key");
+                return;
             }
         }
     }

--- a/ApiKeyGenerator.Benchmarks/ApiKeyGenerator.Benchmarks.csproj
+++ b/ApiKeyGenerator.Benchmarks/ApiKeyGenerator.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\ApiKeyGenerator.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
+    </ItemGroup>
+
+</Project>

--- a/ApiKeyGenerator.Benchmarks/PersistedKey.cs
+++ b/ApiKeyGenerator.Benchmarks/PersistedKey.cs
@@ -1,0 +1,15 @@
+﻿using System.Security.Claims;
+using ApiKeyGenerator.Interfaces;
+
+namespace ApiKeyGenerator.Benchmarks;
+
+public class PersistedKey : IPersistedApiKey
+{
+    public Guid ApiKeyId { get; set; }
+    public string Salt { get; set; } = string.Empty;
+    public string Hash { get; set; } = string.Empty;
+    public string KeyName { get; set; } = string.Empty;
+    public bool? IsRevoked { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public List<Claim> Claims { get; set; } = new();
+}

--- a/ApiKeyGenerator.Benchmarks/Program.cs
+++ b/ApiKeyGenerator.Benchmarks/Program.cs
@@ -2,11 +2,13 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-class Program
+namespace ApiKeyGenerator.Benchmarks
 {
-    static void Main(string[] args)
+    class Program
     {
-        var summary = BenchmarkRunner.Run<AlgorithmBenchmarks>();
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<AlgorithmBenchmarks>();
+        }
     }
-    
 }

--- a/ApiKeyGenerator.Benchmarks/Program.cs
+++ b/ApiKeyGenerator.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+﻿using ApiKeyGenerator.Benchmarks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run<AlgorithmBenchmarks>();
+    }
+    
+}

--- a/ApiKeyGenerator.Benchmarks/Program.cs
+++ b/ApiKeyGenerator.Benchmarks/Program.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Running;
 
 namespace ApiKeyGenerator.Benchmarks
 {
-    class Program
+    static class Program
     {
         static void Main(string[] args)
         {

--- a/ApiKeyGenerator.Benchmarks/TestRepository.cs
+++ b/ApiKeyGenerator.Benchmarks/TestRepository.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ApiKeyGenerator.Interfaces;
+
+namespace ApiKeyGenerator.Benchmarks;
+
+public class TestRepository : IApiKeyRepository
+{
+    private Dictionary<Guid, IPersistedApiKey> _dictionary = new();
+    
+    public ApiKeyAlgorithm? Algorithm { get; set; }
+
+    public async Task<IPersistedApiKey?> GetKey(Guid id)
+    {
+        await Task.CompletedTask;
+        if (_dictionary.TryGetValue(id, out var key))
+        {
+            return key;
+        }
+
+        return null;
+    }
+
+    public async Task<bool> SaveKey(IPersistedApiKey key)
+    {
+        await Task.CompletedTask;
+        _dictionary[key.ApiKeyId] = key;
+        return true;
+    }
+
+    public IEnumerable<ApiKeyAlgorithm>? GetSupportedAlgorithms()
+    {
+        if (Algorithm == null)
+        {
+            return null;
+        }
+
+        return new[] { Algorithm };
+    }
+
+    public ApiKeyAlgorithm? GetNewKeyAlgorithm()
+    {
+        return Algorithm;
+    }
+}

--- a/ApiKeyGenerator.Benchmarks/TestRepository.cs
+++ b/ApiKeyGenerator.Benchmarks/TestRepository.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using ApiKeyGenerator.Interfaces;
+﻿using ApiKeyGenerator.Interfaces;
 
 namespace ApiKeyGenerator.Benchmarks;
 
 public class TestRepository : IApiKeyRepository
 {
-    private Dictionary<Guid, IPersistedApiKey> _dictionary = new();
+    private readonly Dictionary<Guid, IPersistedApiKey> _dictionary = new();
     
     public ApiKeyAlgorithm? Algorithm { get; set; }
 

--- a/ApiKeyGenerator.Tests/BasicKeyTests.cs
+++ b/ApiKeyGenerator.Tests/BasicKeyTests.cs
@@ -7,10 +7,23 @@ namespace ApiKeyGenerator.Tests;
 [TestClass]
 public class BasicKeyTests
 {
-    [TestMethod]
-    public async Task TestKeyGeneration()
+    [DataTestMethod]
+    [DataRow(HashAlgorithmType.SHA256)]
+    [DataRow(HashAlgorithmType.SHA512)]
+    [DataRow(HashAlgorithmType.BCrypt)]
+    public async Task TestAlgorithm(HashAlgorithmType hashType)
     {
-        var repository = new TestRepository();
+        var repository = new TestRepository
+        {
+            Algorithm = new ApiKeyAlgorithm()
+            {
+                Hash = hashType,
+                SaltLength = 64,
+                ClientSecretLength = 64,
+                Prefix = "key",
+                Suffix = "yek",
+            }
+        };
         var validator = new ApiKeyValidator(repository);
         
         // Generate a key
@@ -22,7 +35,7 @@ public class BasicKeyTests
         var apiKeyString = await validator.GenerateApiKey(persistedKey);
         Assert.AreNotEqual(string.Empty, apiKeyString);
         Assert.AreNotEqual(Guid.Empty, persistedKey.ApiKeyId);
-        
+
         // Validate the key
         var validated = await validator.TryValidate(apiKeyString);
         Assert.IsNotNull(validated);
@@ -30,4 +43,5 @@ public class BasicKeyTests
         Assert.AreEqual(persistedKey.ApiKeyId, validated.ApiKey.ApiKeyId);
         Assert.AreEqual(persistedKey.KeyName, validated.ApiKey.KeyName);
     }
+
 }

--- a/ApiKeyGenerator.Tests/BasicKeyTests.cs
+++ b/ApiKeyGenerator.Tests/BasicKeyTests.cs
@@ -44,4 +44,63 @@ public class BasicKeyTests
         Assert.AreEqual(persistedKey.KeyName, validated.ApiKey.KeyName);
     }
 
+    [DataTestMethod]
+    [DataRow(HashAlgorithmType.SHA256)]
+    [DataRow(HashAlgorithmType.SHA512)]
+    [DataRow(HashAlgorithmType.BCrypt)]
+    public async Task TestFailureModes(HashAlgorithmType hashType)
+    {
+        var repository = new TestRepository
+        {
+            Algorithm = new ApiKeyAlgorithm()
+            {
+                Hash = hashType,
+                SaltLength = 64,
+                ClientSecretLength = 64,
+                Prefix = "key",
+                Suffix = "yek",
+            }
+        };
+        var validator = new ApiKeyValidator(repository);
+        
+        // Generate a key
+        var persistedKey = new PersistedApiKey
+        {
+            KeyName = "TestKeyGeneration"
+        };
+        Assert.AreEqual(Guid.Empty, persistedKey.ApiKeyId);
+        var apiKeyString = await validator.GenerateApiKey(persistedKey);
+        Assert.AreNotEqual(string.Empty, apiKeyString);
+        Assert.AreNotEqual(Guid.Empty, persistedKey.ApiKeyId);
+
+        // Break the prefix and attempt to validate
+        var result = await validator.TryValidate("extra" + apiKeyString);
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("Key prefix does not match any supported key algorithms.", result.Message);
+
+        // Break the suffix and attempt to validate
+        var result2 = await validator.TryValidate(apiKeyString + "extra");
+        Assert.IsNotNull(result2);
+        Assert.IsFalse(result2.Success);
+        Assert.AreEqual("This key was truncated and is missing some data.", result2.Message);
+
+        // Try random garbage
+        var result3 = await validator.TryValidate(repository.Algorithm.Prefix + "abc" + repository.Algorithm.Suffix);
+        Assert.IsNotNull(result3);
+        Assert.IsFalse(result3.Success);
+        Assert.AreEqual("Key and client secret are not properly delimited.", result3.Message);
+        
+        // Try properly delimited garbage
+        var result4 = await validator.TryValidate(repository.Algorithm.Prefix + "abc:123" + repository.Algorithm.Suffix);
+        Assert.IsNotNull(result4);
+        Assert.IsFalse(result4.Success);
+        Assert.AreEqual("Key ID is not properly formatted.", result4.Message);
+        
+        // Try properly delimited garbage
+        var result5 = await validator.TryValidate(repository.Algorithm.Prefix + Convert.ToBase64String(Guid.NewGuid().ToByteArray()) + ":123" + repository.Algorithm.Suffix);
+        Assert.IsNotNull(result5);
+        Assert.IsFalse(result5.Success);
+        Assert.AreEqual("Repository does not contain a key matching this ID.", result5.Message);
+    }
 }

--- a/ApiKeyGenerator.Tests/BasicKeyTests.cs
+++ b/ApiKeyGenerator.Tests/BasicKeyTests.cs
@@ -78,6 +78,12 @@ public class BasicKeyTests
         Assert.IsNotNull(result0);
         Assert.IsFalse(result0.Success);
         Assert.AreEqual("Key is null or empty.", result0.Message);
+        
+        // Alternative interfaces test
+        var matchingKey = validator.ParseKey(apiKeyString, repository.Algorithm);
+        Assert.IsNotNull(matchingKey);
+        var ex = Assert.ThrowsException<Exception>(() => validator.ParseKey("", null));
+        Assert.AreEqual("Key is null or empty.", ex.Message);
 
         // Break the prefix and attempt to validate
         var result1 = await validator.TryValidate("extra" + apiKeyString);

--- a/ApiKeyGenerator.Tests/TestRepository.cs
+++ b/ApiKeyGenerator.Tests/TestRepository.cs
@@ -8,6 +8,8 @@ namespace ApiKeyGenerator.Tests;
 public class TestRepository : IApiKeyRepository
 {
     private Dictionary<Guid, IPersistedApiKey> _dictionary = new();
+    
+    public ApiKeyAlgorithm? Algorithm { get; set; }
 
     public async Task<IPersistedApiKey?> GetKey(Guid id)
     {
@@ -29,11 +31,16 @@ public class TestRepository : IApiKeyRepository
 
     public IEnumerable<ApiKeyAlgorithm>? GetSupportedAlgorithms()
     {
-        return null;
+        if (Algorithm == null)
+        {
+            return null;
+        }
+
+        return new[] { Algorithm };
     }
 
     public ApiKeyAlgorithm? GetNewKeyAlgorithm()
     {
-        return null;
+        return Algorithm;
     }
 }

--- a/ApiKeyGenerator.sln
+++ b/ApiKeyGenerator.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{9A88F86E
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		.github\workflows\nuget-publish.yml = .github\workflows\nuget-publish.yml
 		api-key-generator.nuspec = api-key-generator.nuspec
+		PatchNotes.md = PatchNotes.md
 	EndProjectSection
 EndProject
 Global

--- a/ApiKeyGenerator.sln
+++ b/ApiKeyGenerator.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{9A88F86E
 		PatchNotes.md = PatchNotes.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiKeyGenerator.Benchmarks", "ApiKeyGenerator.Benchmarks\ApiKeyGenerator.Benchmarks.csproj", "{D4B63829-8924-4551-A067-91165F759201}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,5 +31,9 @@ Global
 		{8A742AB5-ED8C-48D7-8C05-B14450C5F799}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A742AB5-ED8C-48D7-8C05-B14450C5F799}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A742AB5-ED8C-48D7-8C05-B14450C5F799}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4B63829-8924-4551-A067-91165F759201}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4B63829-8924-4551-A067-91165F759201}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4B63829-8924-4551-A067-91165F759201}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4B63829-8924-4551-A067-91165F759201}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -2,8 +2,11 @@
 July 13, 2023
 
 Switch to BCrypt for the default API key hash algorithm.
-Switch to system cryptographic random number generator.
-Supports SHA256, SHA512, and BCrypt.
+* Support for SHA256, SHA512, BCrypt, and PBKDF2 with 100K iterations.
+* Switched from Base64 encoding to Base58, and replaced the colon separator with an underscore. Using
+this approach, no un-copyable characters appear in an API key.  This should lead to users being able
+to double click an API key and copy it easily.
+* Added many more tests.
 
 # 0.9.1
 July 13, 2023

--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,3 +1,10 @@
+# 0.9.2
+July 13, 2023
+
+Switch to BCrypt for the default API key hash algorithm.
+Switch to system cryptographic random number generator.
+Supports SHA256, SHA512, and BCrypt.
+
 # 0.9.1
 July 13, 2023
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,19 @@ For usability, this library works on a few basic principles:
 * The Key ID is a GUID that can be used to uniquely identify the key in your storage system.
 * Salt and hash values can be stored wherever you like, as long as you can fetch them back for validation.  
 * The validation and key generation logic are as general purpose as possible so you can fit this library anywhere.
+
+# Algorithm Performance
+
+These performance statistics were measured on my laptop, a Dell I7-12700H.  Benchmarks measure the length of time
+taken to do 1,000 iterations of Generate or Validate.
+
+|   Method |   HashType |          Mean |      Error |     StdDev |
+|--------- |----------- |--------------:|-----------:|-----------:|
+| Generate |     SHA256 |      2.659 ms |  0.0269 ms |  0.0239 ms |
+| Validate |     SHA256 |      1.214 ms |  0.0091 ms |  0.0085 ms |
+| Generate |     SHA512 |      3.321 ms |  0.0217 ms |  0.0203 ms |
+| Validate |     SHA512 |      1.821 ms |  0.0078 ms |  0.0061 ms |
+| Generate |     BCrypt | 12,097.053 ms | 32.9440 ms | 30.8158 ms |
+| Validate |     BCrypt | 12,183.813 ms | 39.5346 ms | 36.9807 ms |
+| Generate | PBKDF2100K |  9,105.861 ms | 32.3737 ms | 30.2824 ms |
+| Validate | PBKDF2100K |  9,153.661 ms | 51.2219 ms | 47.9130 ms |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ and validation using relatively safe practices.
 The goal of this library is to strike the right balance between usability and reliability.
 
 This library implements encryption of API keys as follows:
-* Encryption uses SHA256 on key + salt.
+* The default algorithm uses BCrypt on key + salt.
+* You can choose SHA256 or SHA512 if you prefer.
 * Keys and salts are 512 bits of randomness. 
 
 The library is intended to support future generations of algorithms while still being compatible with previously
@@ -24,9 +25,5 @@ For usability, this library works on a few basic principles:
 * The prefix and suffix values determine if the client is sending the wrong API key, or if the key has been truncated.
 * The prefix and suffix also determine which generation of algorithm your key uses.
 * The Key ID is a GUID that can be used to uniquely identify the key in your storage system.
-* Keys can be stored in a database, REDIS, filesystem, or any other persistence mechanism.  
+* Salt and hash values can be stored wherever you like, as long as you can fetch them back for validation.  
 * The validation and key generation logic are as general purpose as possible so you can fit this library anywhere.
-
-# Using the API Key Generator
-
-Still working on this documentation

--- a/api-key-generator.nuspec
+++ b/api-key-generator.nuspec
@@ -23,13 +23,19 @@
 			July 13, 2023
 			
 			Switch to BCrypt for the default API key hash algorithm.
+			* Support for SHA256, SHA512, BCrypt, and PBKDF2 with 100K iterations.
+			* Switched from Base64 encoding to Base58, and replaced the colon separator with an underscore. Using
+			this approach, no un-copyable characters appear in an API key.  This should lead to users being able
+			to double click an API key and copy it easily.
+			* Added many more tests.
 		</releaseNotes>
 		<copyright>Copyright 2023 - 2023</copyright>
     	<tags>apikey rest authentication authorization bearer token api-key</tags>
 		<repository type="git" url="https://github.com/tspence/csharp-searchlight" />
 		<dependencies>
-			<group targetFramework=".NETStandard2.0">
+			<group targetFramework=".NETStandard2.1">
 				<dependency id="BCrypt.Net-Next" version="4.0.3" />
+				<dependency id="SimpleBase" version="4.0.0" />
 			</group>
 		</dependencies>
 	</metadata>
@@ -38,6 +44,6 @@
 		<file src=".\README.md" target="docs/README.md"/>
 		<file src=".\api-key-generator.png" target="docs/api-key-generator.png"/>
 		<file src=".\PatchNotes.md" target="docs/PatchNotes.md"/>
-		<file src="src\bin\Release\netstandard2.0\*" target="lib\netstandard20" />
+		<file src="src\bin\Release\netstandard2.1\*" target="lib\netstandard20" />
 	</files>
 </package>

--- a/api-key-generator.nuspec
+++ b/api-key-generator.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>ApiKeyGenerator</id>
-		<version>0.9.1</version>
+		<version>0.9.2</version>
 		<title>ApiKeyGenerator</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -19,10 +19,10 @@
 		<summary>Generate and validate API Keys in a `salt + key => hash` format.</summary>
 		<icon>docs/api-key-generator.png</icon>
 		<releaseNotes>
-			# 0.9.1
+			# 0.9.2
 			July 13, 2023
 			
-			First release to NuGet; still in development.
+			Switch to BCrypt for the default API key hash algorithm.
 		</releaseNotes>
 		<copyright>Copyright 2023 - 2023</copyright>
     	<tags>apikey rest authentication authorization bearer token api-key</tags>

--- a/api-key-generator.nuspec
+++ b/api-key-generator.nuspec
@@ -28,7 +28,9 @@
     	<tags>apikey rest authentication authorization bearer token api-key</tags>
 		<repository type="git" url="https://github.com/tspence/csharp-searchlight" />
 		<dependencies>
-			<group targetFramework=".NETStandard2.0"/>
+			<group targetFramework=".NETStandard2.0">
+				<dependency id="BCrypt.Net-Next" version="4.0.3" />
+			</group>
 		</dependencies>
 	</metadata>
 	<files>

--- a/src/ApiKeyAlgorithm.cs
+++ b/src/ApiKeyAlgorithm.cs
@@ -5,14 +5,14 @@
         /// <summary>
         /// Default algorithm:
         /// * Prefix and Suffix are "api" and "key" slightly mixed up
-        /// * Hash algorithm is SHA256
-        /// * Client secret and salt are both 512 bits / 64 bytes
+        /// * Hash algorithm is BCrypt
+        /// * Client secret and salt are both 512 bits (64 bytes)
         /// </summary>
         public static ApiKeyAlgorithm DefaultAlgorithm = new ApiKeyAlgorithm()
         {
-            Prefix = "kpy",
+            Prefix = "kpb",
             Suffix = "aei",
-            Hash = HashAlgorithmType.SHA256,
+            Hash = HashAlgorithmType.BCrypt,
             ClientSecretLength = 64,
             SaltLength = 64,
         };

--- a/src/ApiKeyAlgorithm.cs
+++ b/src/ApiKeyAlgorithm.cs
@@ -17,10 +17,27 @@
             SaltLength = 64,
         };
         
+        /// <summary>
+        /// The prefix to use when generating an API key string for client use.
+        /// </summary>
         public string Prefix { get; set; }
+        /// <summary>
+        /// The suffix to use when generating an API key string for client use.
+        /// </summary>
         public string Suffix { get; set; }
+        /// <summary>
+        /// The hash algorithm to use.  Note that BCrypt is significantly slower
+        /// than SHA256 or SHA512, but it is more resistant to brute force attacks.
+        /// </summary>
         public HashAlgorithmType Hash { get; set; }
+        /// <summary>
+        /// The number of bytes to use for the length of the client secret.
+        /// </summary>
         public int ClientSecretLength { get; set; }
+        /// <summary>
+        /// The number of bytes to use for the salt. In the case of BCrypt, this value
+        /// is ignored and BCrypt's recommended salt length is used instead.
+        /// </summary>
         public int SaltLength { get; set; }
     }
 }

--- a/src/ApiKeyGenerator.csproj
+++ b/src/ApiKeyGenerator.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <ImplicitUsings>false</ImplicitUsings>
         <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+      <PackageReference Include="SimpleBase" Version="4.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/ApiKeyGenerator.csproj
+++ b/src/ApiKeyGenerator.csproj
@@ -6,4 +6,8 @@
         <Nullable>disable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    </ItemGroup>
+
 </Project>

--- a/src/ApiKeyValidator.cs
+++ b/src/ApiKeyValidator.cs
@@ -75,13 +75,14 @@ namespace ApiKeyGenerator
         /// <summary>
         /// Parses the key and throws an exception if the key is malformed
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        /// <exception cref="Exception"></exception>
-        public ClientApiKey ParseKey(string key, ApiKeyAlgorithm algorithm)
+        /// <param name="keyString">The client API key string to test</param>
+        /// <param name="algorithm">The algorithm to use, or null to use the default</param>
+        /// <returns>The matching API key if successful</returns>
+        /// <exception cref="Exception">If not successful, an exception explaining why it was not validated</exception>
+        public ClientApiKey ParseKey(string keyString, ApiKeyAlgorithm algorithm = null)
         {
-            if (!TryParseKey(key, algorithm, out var value, out var message))
+            var realAlgorithm = algorithm ?? ApiKeyAlgorithm.DefaultAlgorithm;
+            if (!TryParseKey(keyString, realAlgorithm, out var value, out var message))
             {
                 throw new Exception(message);
             }

--- a/src/HashAlgorithmType.cs
+++ b/src/HashAlgorithmType.cs
@@ -2,7 +2,8 @@
 {
     public enum HashAlgorithmType
     {
-        // Primary algorithm supported for now; can potentially support others in the future
         SHA256 = 1,
+        SHA512 = 2,
+        BCrypt = 3,
     }
 }

--- a/src/HashAlgorithmType.cs
+++ b/src/HashAlgorithmType.cs
@@ -5,5 +5,6 @@
         SHA256 = 1,
         SHA512 = 2,
         BCrypt = 3,
+        PBKDF2100K = 4,
     }
 }

--- a/src/Interfaces/IPersistedApiKey.cs
+++ b/src/Interfaces/IPersistedApiKey.cs
@@ -23,7 +23,7 @@ namespace ApiKeyGenerator.Interfaces
         string Salt { get; set; }
 
         /// <summary>
-        /// This is the hash computed as SHA256(ClientSecret + Salt) and stored using Base64.
+        /// This is the hash computed as Hash_Algorithm(ClientSecret + Salt).
         /// </summary>
         string Hash { get; set; }
         

--- a/src/Keys/ClientApiKey.cs
+++ b/src/Keys/ClientApiKey.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ApiKeyGenerator.Interfaces;
+using SimpleBase;
 
 namespace ApiKeyGenerator.Keys
 {
@@ -29,8 +30,8 @@ namespace ApiKeyGenerator.Keys
         public string ToApiKeyString(ApiKeyAlgorithm algorithm)
         {
             var idBytes = ApiKeyId.ToByteArray();
-            var idString = Convert.ToBase64String(idBytes);
-            return $"{algorithm.Prefix}{idString}:{ClientSecret}{algorithm.Suffix}";
+            var idString = ApiKeyValidator.Encode(idBytes);
+            return $"{algorithm.Prefix}{idString}{ApiKeyValidator.Separator}{ClientSecret}{algorithm.Suffix}";
         }
     }
 }


### PR DESCRIPTION
A few improvements.
* Replace random with cryptography random.
* Switch to BCrypt as default algorithm and depend on BCrypt.net-next.
* Modify nuget-publish to only run when merging to develop.
* Update version number to 0.9.2.