### PR TITLE
Remove dependency on SimpleBase; support NetStandard2.0

### DIFF
--- a/ApiKeyGenerator.Tests/ApiKeyGenerator.Tests.csproj
+++ b/ApiKeyGenerator.Tests/ApiKeyGenerator.Tests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" />
+        <PackageReference Include="SimpleBase" Version="4.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ApiKeyGenerator.Tests/RippleBase58Test.cs
+++ b/ApiKeyGenerator.Tests/RippleBase58Test.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ApiKeyGenerator.Tests;
+
+[TestClass]
+public class RippleBase58Test
+{
+    [TestMethod]
+    public void BasicRippleTest()
+    {
+        // Encode and decode a bunch of guids to verify sanity
+        for (int i = 0; i < 100; i++)
+        {
+            var guid = Guid.NewGuid();
+            var rippleText = Base58Ripple.Encode(guid.ToByteArray());
+            Assert.IsNotNull(rippleText);
+            var outputBytes = new byte[16];
+            var success = Base58Ripple.TryDecode(rippleText, outputBytes, out var numBytesWritten);
+            Assert.IsTrue(success);
+            Assert.AreEqual(16, numBytesWritten);
+            var decodedGuid = new Guid(outputBytes);
+            Assert.AreEqual(guid, decodedGuid);
+        }
+    }
+
+    [TestMethod]
+    public void EncodingMatchesSimpleBase()
+    {
+        // We previously used the library SimpleBase for encoding.
+        // However, SimpleBase enforces dependency rules on us - we want to be able to
+        // support NetStandard 2.0 and SimpleBase doesn't anymore.  So we'll eliminate
+        // this dependency and ensure that our code works interoperably with theirs.
+        for (int i = 0; i < 100; i++)
+        {
+            var guid = Guid.NewGuid();
+            var rippleText = SimpleBase.Base58.Ripple.Encode(guid.ToByteArray());
+            Assert.IsNotNull(rippleText);
+            var outputBytes = new byte[16];
+            var success = Base58Ripple.TryDecode(rippleText, outputBytes, out var numBytesWritten);
+            Assert.IsTrue(success);
+            Assert.AreEqual(16, numBytesWritten);
+            var decodedGuid = new Guid(outputBytes);
+            Assert.AreEqual(guid, decodedGuid);
+        }
+        
+    }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -26,3 +26,4 @@ SOFTWARE.
 Additional License Information
 
 * Icon by WiStudio from https://freeicons.io/non-fungible-token-icon-set-5/ownership-nonfungibletoken-nft-holder-owner-key-authority-icon-313039
+* Base58 ripple logic adapted from https://gist.github.com/micli/c242edd2a81a8f0d9f7953842bcc24f1

--- a/src/ApiKeyGenerator.csproj
+++ b/src/ApiKeyGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>false</ImplicitUsings>
         <Nullable>disable</Nullable>
         <PackageReadmeFile>docs/README.md</PackageReadmeFile>
@@ -14,22 +14,20 @@
         <PackageTags>apikey rest authentication authorization bearer token api-key</PackageTags>
         <Copyright>Copyright 2021 - 2023</Copyright>
         <PackageReleaseNotes>
-            # 0.9.4
-            September 21, 2023
+            # 0.9.5
+            September 24, 2023
 
-            Update library to avoid usage of nuspec files.
-            Refactoring to address some SonarCloud reported items.
+            Support NetStandard 2.0; remove dependency on SimpleBase.
         </PackageReleaseNotes>
         <PackageIcon>docs/api-key-generator.png</PackageIcon>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.9.4</Version>
+        <Version>0.9.5</Version>
         <Authors>Ted Spence</Authors>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-        <PackageReference Include="SimpleBase" Version="4.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ApiKeyValidator.cs
+++ b/src/ApiKeyValidator.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using ApiKeyGenerator.Exceptions;
 using ApiKeyGenerator.Interfaces;
 using ApiKeyGenerator.Keys;
-using SimpleBase;
 
 namespace ApiKeyGenerator
 {
@@ -170,7 +169,7 @@ namespace ApiKeyGenerator
         /// <returns>The client API key string.</returns>
         public async Task<string> GenerateApiKey(IPersistedApiKey persisted, ApiKeyAlgorithm algorithm = null)
         {
-            algorithm ??= _repository.GetNewKeyAlgorithm() ?? ApiKeyAlgorithm.DefaultAlgorithm;
+            algorithm = algorithm ?? _repository.GetNewKeyAlgorithm() ?? ApiKeyAlgorithm.DefaultAlgorithm;
             var keyId = Guid.NewGuid();
             var rand = RandomNumberGenerator.Create();
             var secretBytes = new byte[algorithm.ClientSecretLength];
@@ -232,7 +231,7 @@ namespace ApiKeyGenerator
         /// <returns></returns>
         public static string Encode(byte[] bytes)
         {
-            return Base58.Ripple.Encode(bytes);
+            return Base58Ripple.Encode(bytes);
         }
 
         internal static bool TryDecode(string text, int expectedLength, out byte[] bytes)
@@ -244,7 +243,7 @@ namespace ApiKeyGenerator
             try
             {
                 bytes = new byte[expectedLength];
-                var success = Base58.Ripple.TryDecode(text, bytes, out var numBytesWritten);
+                var success = Base58Ripple.TryDecode(text, bytes, out var numBytesWritten);
                 return success && numBytesWritten == expectedLength;
             }
             catch

--- a/src/Base58Ripple.cs
+++ b/src/Base58Ripple.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Text;
+
+namespace ApiKeyGenerator
+{
+    /// <summary>
+    /// Code adapted from micli, https://gist.github.com/micli/c242edd2a81a8f0d9f7953842bcc24f1 
+    /// </summary>
+    public static class Base58Ripple
+    {
+        // We use the Ripple alphabet
+        public static readonly char[]
+            _alphabet = "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz".ToCharArray();
+
+        private static int[] _indexes = null;
+
+        private static int[] GetIndexes()
+        {
+            if (_indexes == null)
+            {
+                _indexes = new int[128];
+                for (int i = 0; i < _indexes.Length; i++)
+                {
+                    _indexes[i] = -1;
+                }
+
+                for (int i = 0; i < _alphabet.Length; i++)
+                {
+                    _indexes[_alphabet[i]] = i;
+                }
+            }
+
+            return _indexes;
+        }
+
+        public static string Encode(byte[] input)
+        {
+            if (0 == input.Length)
+            {
+                return string.Empty;
+            }
+
+            input = CopyOfRange(input, 0, input.Length);
+            // Count leading zeroes.
+            int zeroCount = 0;
+            while (zeroCount < input.Length && input[zeroCount] == 0)
+            {
+                zeroCount++;
+            }
+
+            // The actual encoding.
+            byte[] temp = new byte[input.Length * 2];
+            int j = temp.Length;
+
+            int startAt = zeroCount;
+            while (startAt < input.Length)
+            {
+                byte mod = DivMod58(input, startAt);
+                if (input[startAt] == 0)
+                {
+                    startAt++;
+                }
+
+                temp[--j] = (byte)_alphabet[mod];
+            }
+
+            // Strip extra '1' if there are some after decoding.
+            while (j < temp.Length && temp[j] == _alphabet[0])
+            {
+                ++j;
+            }
+
+            // Add as many leading '1' as there were leading zeros.
+            while (--zeroCount >= 0)
+            {
+                temp[--j] = (byte)_alphabet[0];
+            }
+
+            byte[] output = CopyOfRange(temp, j, temp.Length);
+            try
+            {
+                return Encoding.ASCII.GetString(output);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static bool TryDecode(string input, byte[] bytes, out int numBytesWritten)
+        {
+            numBytesWritten = 0;
+            if (0 == input.Length)
+            {
+                return false;
+            }
+
+            var indexes = GetIndexes();
+            byte[] input58 = new byte[input.Length];
+
+            // Transform the String to a base58 byte sequence
+            for (int i = 0; i < input.Length; i++)
+            {
+                char c = input[i];
+
+                int digit58 = -1;
+                if (c >= 0 && c < 128)
+                {
+                    digit58 = indexes[c];
+                }
+
+                if (digit58 < 0)
+                {
+                    //throw new ArgumentException($"Illegal character {c} ({(int)c} at position {i}");
+                    return false;
+                }
+
+                input58[i] = (byte)digit58;
+            }
+
+            // Count leading zeroes
+            int zeroCount = 0;
+            while (zeroCount < input58.Length && input58[zeroCount] == 0)
+            {
+                zeroCount++;
+            }
+
+            // The encoding
+            byte[] temp = new byte[input.Length];
+            int j = temp.Length;
+
+            int startAt = zeroCount;
+            while (startAt < input58.Length)
+            {
+                byte mod = DivMod256(input58, startAt);
+                if (input58[startAt] == 0)
+                {
+                    ++startAt;
+                }
+
+                temp[--j] = mod;
+            }
+
+            // Do no add extra leading zeroes, move j to first non null byte.
+            while (j < temp.Length && temp[j] == 0)
+            {
+                j++;
+            }
+
+            var output = CopyOfRange(temp, j - zeroCount, temp.Length);
+            for (int i = 0; i < output.Length; i++)
+            {
+                bytes[i] = output[i];
+            }
+
+            numBytesWritten = output.Length;
+            return true;
+        }
+
+        private static byte DivMod58(byte[] number, int startAt)
+        {
+            int remainder = 0;
+            for (int i = startAt; i < number.Length; i++)
+            {
+                int digit256 = (int)number[i] & 0xFF;
+                int temp = remainder * 256 + digit256;
+
+                number[i] = (byte)(temp / 58);
+
+                remainder = temp % 58;
+            }
+
+            return (byte)remainder;
+        }
+
+        private static byte DivMod256(byte[] number58, int startAt)
+        {
+            int remainder = 0;
+            for (int i = startAt; i < number58.Length; i++)
+            {
+                int digit58 = (int)number58[i] & 0xFF;
+                int temp = remainder * 58 + digit58;
+
+                number58[i] = (byte)(temp / 256);
+
+                remainder = temp % 256;
+            }
+
+            return (byte)remainder;
+        }
+
+        private static byte[] CopyOfRange(byte[] source, int from, int to)
+        {
+            byte[] range = new byte[to - from];
+            for (int i = 0; i < to - from; i++)
+            {
+                range[i] = source[from + i];
+            }
+
+            return range;
+        }
+    }
+}

--- a/src/Base58Ripple.cs
+++ b/src/Base58Ripple.cs
@@ -9,7 +9,7 @@ namespace ApiKeyGenerator
     public static class Base58Ripple
     {
         // We use the Ripple alphabet
-        public static readonly char[]
+        private static readonly char[]
             _alphabet = "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz".ToCharArray();
 
         private static int[] _indexes = null;
@@ -111,7 +111,7 @@ namespace ApiKeyGenerator
 
                 if (digit58 < 0)
                 {
-                    //throw new ArgumentException($"Illegal character {c} ({(int)c} at position {i}");
+                    // Illegal character {c} ({(int)c} at position {i}
                     return false;
                 }
 

--- a/src/Keys/ClientApiKey.cs
+++ b/src/Keys/ClientApiKey.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using ApiKeyGenerator.Interfaces;
-using SimpleBase;
 
 namespace ApiKeyGenerator.Keys
 {

--- a/src/PatchNotes.md
+++ b/src/PatchNotes.md
@@ -1,3 +1,8 @@
+# 0.9.5
+September 24, 2023
+
+Support NetStandard 2.0; remove dependency on SimpleBase.
+
 # 0.9.4
 September 21, 2023
 


### PR DESCRIPTION
SimpleBase required us to be on NetStandard2.0.  Since we were only using it for two functions - Base58Encode and Base58Decode - let's write our own versions using some examples posted online and remove this dependency.